### PR TITLE
Endpoint para la peticion de traducciones

### DIFF
--- a/src/gpt/dtos/translate.dto.ts
+++ b/src/gpt/dtos/translate.dto.ts
@@ -1,0 +1,9 @@
+import { IsString } from "class-validator";
+
+
+export class TranslateDto{
+    @IsString()
+    prompt: string;
+    @IsString()
+    lang: string;
+}

--- a/src/gpt/gpt.controller.ts
+++ b/src/gpt/gpt.controller.ts
@@ -3,6 +3,7 @@ import { GptService } from './gpt.service';
 import { OrthographyDto } from './dtos/orthography.dto';
 import { ProsConsDiscuserDto } from './dtos/proscons.discuser';
 import { Response } from 'express';
+import { TranslateDto } from './dtos/translate.dto';
 
 @Controller('gpt')
 export class GptController {
@@ -34,6 +35,11 @@ export class GptController {
     }
 
     res.end();
+  }
+
+  @Post('translate')
+  async translate(@Body() translateDto: TranslateDto) {
+    return this.gptService.translateService( translateDto );
   }
   
 }

--- a/src/gpt/gpt.service.ts
+++ b/src/gpt/gpt.service.ts
@@ -5,6 +5,8 @@ import OpenAI from 'openai';
 import { ProsConsDiscuserDto } from './dtos/proscons.discuser';
 import { prosConsDicusserUseCase } from './use-cases/proscons-discuser.use-case';
 import { prosConsDicusserStreamUseCase } from './use-cases/proscons-discuser-stream.use-case';
+import { TranslateDto } from './dtos/translate.dto';
+import { translateUseCase } from './use-cases/translate.use-case';
 
 @Injectable()
 export class GptService {
@@ -25,5 +27,9 @@ export class GptService {
 
     async prosConsDicusserStream({ prompt }: ProsConsDiscuserDto) {
         return await prosConsDicusserStreamUseCase(this.openAi, { prompt });
+    }
+
+    async translateService({ prompt, lang }: TranslateDto) {
+        return await translateUseCase(this.openAi, { prompt, lang });
     }
 }

--- a/src/gpt/use-cases/proscons-discuser.use-case.ts
+++ b/src/gpt/use-cases/proscons-discuser.use-case.ts
@@ -34,5 +34,5 @@ export const prosConsDicusserUseCase = async( openAi: OpenAI, options: Options) 
         } */
     });
     //const jsonResp = JSON.parse(response.choices[0].message.content!);
-    return response.choices[0].message.content!;
+    return response.choices[0].message;
 }

--- a/src/gpt/use-cases/translate.use-case.ts
+++ b/src/gpt/use-cases/translate.use-case.ts
@@ -1,0 +1,31 @@
+
+
+import OpenAI from "openai";
+
+
+interface Options{
+    prompt: string;
+    lang: string;
+    
+}
+
+export const translateUseCase = async( openAi: OpenAI, options: Options) => {
+    const { prompt, lang } = options;
+
+
+    const response = await openAi.chat.completions.create({
+        messages: [{ 
+            role: "system", 
+            content:`Traduce el siguiente texto al idioma ${lang}:${ prompt }` 
+        },
+    ],
+        model: "gpt-4.1",
+        temperature: 0.2,
+        //max_completion_tokens: 500,
+        /* response_format: {
+            type: "json_object",
+        } */
+    });
+    //const jsonResp = JSON.parse(response.choices[0].message.content!);
+    return  {message: response.choices[0].message.content};
+}


### PR DESCRIPTION
Nueva función para la traducción de texto mediante el modelo GPT de OpenAI. Incluye la creación de un nuevo DTO (`TranslateDto`), actualizaciones de las capas de controlador y servicio para gestionar las solicitudes de traducción, y la implementación del caso de uso correspondiente. Además, se realizó un pequeño ajuste en `prosConsDicusserUseCase` para devolver el objeto de mensaje completo en lugar de solo el contenido.

### Nueva función de traducción:

* **Creación de DTO**: Se añadió la clase `TranslateDto` en `src/gpt/dtos/translate.dto.ts` para definir la estructura de las solicitudes de traducción, incluyendo los campos `prompt` y `lang` validados como cadenas.
* **Actualización del controlador**: Se añadió un nuevo punto final POST (`translate`) en `GptController` para gestionar las solicitudes de traducción mediante `TranslateDto`. * **Actualización del servicio**: Se implementó el método `translateService` en `GptService` para procesar las solicitudes de traducción mediante `TranslateDto` y delegar la lógica a `translateUseCase`.
* **Implementación del caso de uso**: Se creó `translateUseCase` en `src/gpt/use-cases/translate.use-case.ts` para interactuar con la API de OpenAI y realizar la traducción según el mensaje y el idioma proporcionados.

### Ajuste de código:

* **Pros/Desventajas del caso de uso**: Se actualizó `prosConsDicusserUseCase` en `src/gpt/use-cases/proscons-discuser.use-case.ts` para devolver el objeto de mensaje completo de la respuesta de OpenAI en lugar de solo el contenido.