### PR TITLE
Recepcion del texto creado desde openAi

### DIFF
--- a/src/gpt/dtos/audio-to-text.dto.ts
+++ b/src/gpt/dtos/audio-to-text.dto.ts
@@ -1,0 +1,9 @@
+
+import { IsOptional, IsString } from "class-validator";
+
+
+export class AudioToTextDto {
+    @IsString()
+    @IsOptional()
+    prompt: string;
+}

--- a/src/gpt/gpt.controller.ts
+++ b/src/gpt/gpt.controller.ts
@@ -7,6 +7,7 @@ import { TranslateDto } from './dtos/translate.dto';
 import { TextToAudioDto } from './dtos/text-to-audio.dto';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { diskStorage } from 'multer';
+import { AudioToTextDto } from './dtos/audio-to-text.dto';
 
 @Controller('gpt')
 export class GptController {
@@ -80,7 +81,22 @@ export class GptController {
           const fileName = `${new Date().getTime()}.${fileExtension}`;
           return callback(null, fileName );
         }
-      }), 
+      }),
+      fileFilter: (req, file, callback) => {
+        const allowedMimes = [
+          'audio/mpeg',
+          'audio/mp4', 
+          'audio/x-m4a',
+          'audio/wav',
+          'audio/webm'
+        ];
+        
+        if (allowedMimes.includes(file.mimetype)) {
+          callback(null, true);
+        } else {
+          callback(new Error('Tipo de archivo no permitido'), false);
+        }
+      }
     })
   )
   async audioToText(
@@ -88,12 +104,13 @@ export class GptController {
       new ParseFilePipe({
         validators:[
           new MaxFileSizeValidator({ maxSize: 1000 * 1024 * 5, message: ' File is bigger than 10Mb' }),
-          new FileTypeValidator({ fileType: 'audio/*' }) // 10 MB
+          
         ]
       })
     ) file: Express.Multer.File,
+    @Body() audioToTextDto: AudioToTextDto
   ) {
-    //return await this.gptService.audioToTextService( textToAudioDto );
-    return 'Done';
+
+    return this.gptService.audioToTextService( file, audioToTextDto );
   }
 }

--- a/src/gpt/gpt.service.ts
+++ b/src/gpt/gpt.service.ts
@@ -11,6 +11,8 @@ import { TextToAudioDto } from './dtos/text-to-audio.dto';
 import { textToAudioUseCase } from './use-cases/text-to-audio.use-case';
 import * as path from 'path';
 import * as fs from 'fs';
+import { audioToTextUseCase } from './use-cases/audio-to-text.use-case';
+import { AudioToTextDto } from './dtos/audio-to-text.dto';
 
 @Injectable()
 export class GptService {
@@ -48,5 +50,10 @@ export class GptService {
         console.log(`File path: ${filePath}`);
 
         return filePath;
+    }
+
+    async audioToTextService( audioFile: Express.Multer.File, audioToTextDto: AudioToTextDto) {
+        const { prompt } = audioToTextDto;
+        return await audioToTextUseCase(this.openAi, { audioFile, prompt });
     }
 }

--- a/src/gpt/use-cases/audio-to-text.use-case.ts
+++ b/src/gpt/use-cases/audio-to-text.use-case.ts
@@ -1,0 +1,22 @@
+import OpenAI from "openai";
+import * as fs from 'fs'
+
+interface Options {
+    prompt?: string;
+    audioFile: Express.Multer.File;
+}
+
+export const audioToTextUseCase = async ( openAi: OpenAI, options: Options) => {
+    const { prompt, audioFile } = options;
+
+    const resp = await openAi.audio.transcriptions.create({
+        model: 'gpt-4o-transcribe',
+        file: fs.createReadStream( audioFile.path ),
+        prompt: prompt, // mismo idioma del audio
+        language: 'es',
+        response_format: 'json',
+    });
+
+    return resp.text || 'No se pudo transcribir el audio, intente de nuevo más tarde';
+
+}


### PR DESCRIPTION
Funcionalidad para transcribir archivos de audio a texto mediante la API de transcripción de OpenAI. Los cambios incluyen la incorporación de un nuevo DTO, la actualización del controlador y el servicio para gestionar solicitudes de audio a texto y la implementación de un caso de uso para la lógica de transcripción. A continuación, se presenta un resumen de los cambios más importantes:

### Implementación del nuevo DTO y caso de uso:

* **`src/gpt/dtos/audio-to-text.dto.ts`:** Se creó la nueva clase `AudioToTextDto` con un campo `prompt` opcional para permitir especificar una pista de transcripción.
* **`src/gpt/use-cases/audio-to-text.use-case.ts`:** Se añadió la función `audioToTextUseCase` para gestionar la lógica de transcripción mediante la API de OpenAI. Acepta un archivo de audio y un mensaje de solicitud opcional, procesa la transcripción y devuelve el resultado.

### Actualizaciones del controlador:

* **`src/gpt/gpt.controller.ts`:**
* Se importó el nuevo `AudioToTextDto` para gestionar las solicitudes de audio a texto.
* Se actualizó el método `audioToText` para incluir un filtro de tipo MIME para los formatos de audio compatibles, validar el tamaño del archivo y pasar el archivo y el DTO al servicio.

### Actualizaciones del servicio:

* **`src/gpt/gpt.service.ts`:**
* Se importaron `audioToTextUseCase` y `AudioToTextDto` para su uso en el servicio.
* Se añadió el nuevo método `audioToTextService` para llamar a `audioToTextUseCase` con el archivo de audio y el mensaje proporcionados.