### PR TITLE
Cambio en la forma de retornopara que devuelva en json completo

### DIFF
--- a/src/gpt/use-cases/audio-to-text.use-case.ts
+++ b/src/gpt/use-cases/audio-to-text.use-case.ts
@@ -17,6 +17,6 @@ export const audioToTextUseCase = async ( openAi: OpenAI, options: Options) => {
         response_format: 'json',
     });
 
-    return resp.text || 'No se pudo transcribir el audio, intente de nuevo más tarde';
+    return resp || 'No se pudo transcribir el audio, intente de nuevo más tarde';
 
 }


### PR DESCRIPTION
This pull request includes a small change to the `audioToTextUseCase` function in `src/gpt/use-cases/audio-to-text.use-case.ts`. The change modifies the return statement to return the entire `resp` object instead of just the `resp.text` property.