### PR TITLE
Caso de uso de generacion de imagen

### DIFF
--- a/src/gpt/dtos/image-genaration.dto.ts
+++ b/src/gpt/dtos/image-genaration.dto.ts
@@ -1,0 +1,16 @@
+import { IsOptional, IsString } from "class-validator";
+
+
+export class ImageGenerationDto {
+    @IsString()
+    readonly prompt: string;
+
+    @IsString()
+    @IsOptional()
+    readonly originalImage?: string; 
+    
+    @IsString()
+    @IsOptional()
+    readonly maskImage?: string;
+
+}

--- a/src/gpt/gpt.controller.ts
+++ b/src/gpt/gpt.controller.ts
@@ -8,6 +8,7 @@ import { TextToAudioDto } from './dtos/text-to-audio.dto';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { diskStorage } from 'multer';
 import { AudioToTextDto } from './dtos/audio-to-text.dto';
+import { ImageGenerationDto } from './dtos/image-genaration.dto';
 
 @Controller('gpt')
 export class GptController {
@@ -112,5 +113,12 @@ export class GptController {
   ) {
 
     return this.gptService.audioToTextService( file, audioToTextDto );
+  }
+
+  @Post('image-generation')
+  async imageGeneration(
+    @Body() imageGenerationDto: ImageGenerationDto
+  ) {
+    return this.gptService.imageGenerationService( imageGenerationDto );
   }
 }

--- a/src/gpt/gpt.service.ts
+++ b/src/gpt/gpt.service.ts
@@ -13,6 +13,8 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { audioToTextUseCase } from './use-cases/audio-to-text.use-case';
 import { AudioToTextDto } from './dtos/audio-to-text.dto';
+import { ImageGenerationDto } from './dtos/image-genaration.dto';
+import { imageGenerationUseCase } from './use-cases/image-generation.use-case';
 
 @Injectable()
 export class GptService {
@@ -55,5 +57,9 @@ export class GptService {
     async audioToTextService( audioFile: Express.Multer.File, audioToTextDto: AudioToTextDto) {
         const { prompt } = audioToTextDto;
         return await audioToTextUseCase(this.openAi, { audioFile, prompt });
+    }
+
+    async imageGenerationService( imageGenerationDto: ImageGenerationDto ) {
+        return imageGenerationUseCase(this.openAi, {...imageGenerationDto });
     }
 }

--- a/src/gpt/use-cases/audio-to-text.use-case copy.ts
+++ b/src/gpt/use-cases/audio-to-text.use-case copy.ts
@@ -1,0 +1,22 @@
+import OpenAI from "openai";
+import * as fs from 'fs'
+
+interface Options {
+    prompt?: string;
+    audioFile: Express.Multer.File;
+}
+
+export const audioToTextUseCase = async ( openAi: OpenAI, options: Options) => {
+    const { prompt, audioFile } = options;
+
+    const resp = await openAi.audio.transcriptions.create({
+        model: 'gpt-4o-transcribe',
+        file: fs.createReadStream( audioFile.path ),
+        prompt: prompt, // mismo idioma del audio
+        language: 'es',
+        response_format: 'json',
+    });
+
+    return resp || 'No se pudo transcribir el audio, intente de nuevo más tarde';
+
+}

--- a/src/gpt/use-cases/image-generation.use-case.ts
+++ b/src/gpt/use-cases/image-generation.use-case.ts
@@ -1,0 +1,32 @@
+
+
+
+import OpenAI from "openai";
+import * as fs from 'fs'
+
+interface Options {
+    prompt: string;
+    originalImage?: string;
+    maskImage?: string;
+}
+
+export const imageGenerationUseCase = async ( openAi: OpenAI, options: Options) => {
+    const { prompt, originalImage, maskImage } = options;
+    const resp = await openAi.images.generate({
+        prompt: prompt,
+        n: 1,
+        size: '1024x1024',
+        model: 'dall-e-3',
+        quality: 'standard',
+        response_format: 'url',
+    });
+   
+    console.log(resp);
+    return {
+        url: resp.data![0].url,
+        localPath: '',
+        revised_prompt: resp.data![0].revised_prompt ,
+    } 
+
+
+}


### PR DESCRIPTION
Funcionalidad para la generación de imágenes mediante el modelo DALL-E de OpenAI. Incluye la creación de un nuevo DTO, un método de servicio y un caso de uso para gestionar las solicitudes de generación de imágenes. Además, se ha añadido un archivo duplicado de caso de uso de "audio a texto".

### Función de Generación de Imágenes:

* **Nuevo DTO para la Generación de Imágenes**: Se ha añadido `ImageGenerationDto` en `src/gpt/dtos/image-genaration.dto.ts` para definir la estructura de las solicitudes entrantes de generación de imágenes, incluyendo campos opcionales para `originalImage` y `maskImage`.
* **Método de Controlador para la Generación de Imágenes**: Se ha añadido un nuevo endpoint `imageGeneration` en `GptController` para gestionar las solicitudes POST y procesarlas mediante `ImageGenerationDto`.
* **Método de Servicio para la Generación de Imágenes**: Se ha añadido `imageGenerationService` en `GptService` para invocar `imageGenerationUseCase` con el DTO proporcionado. **Caso de uso de generación de imágenes**: Se creó `imageGeneration.use-case.ts` para interactuar con la API DALL-E de OpenAI y generar imágenes según la solicitud y las entradas de imagen opcionales.

### Varios:

* **Caso de uso de audio a texto duplicado**: Se agregó un archivo duplicado `audio-to-text.use-case copy.ts` con la misma funcionalidad que el `audio-to-text.use-case.ts` original. Esto parece no ser intencional y podría ser necesario eliminarlo.