### PR TITLE
Obteniendo la imagen guardada en local

### DIFF
--- a/src/gpt/gpt.controller.ts
+++ b/src/gpt/gpt.controller.ts
@@ -121,4 +121,16 @@ export class GptController {
   ) {
     return this.gptService.imageGenerationService( imageGenerationDto );
   }
+
+  @Get('image-generation/:fileName')
+  async getImageGeneration(
+    @Res() res: Response,
+    @Param('fileName') filename: string
+  ) {
+    
+    const filePath =  await  this.gptService.getImageGenerationService( filename );
+    res.setHeader('Content-Type', 'image/png');
+    res.status(HttpStatus.OK);
+    res.sendFile(filePath);
+  }
 }

--- a/src/gpt/gpt.service.ts
+++ b/src/gpt/gpt.service.ts
@@ -62,4 +62,13 @@ export class GptService {
     async imageGenerationService( imageGenerationDto: ImageGenerationDto ) {
         return imageGenerationUseCase(this.openAi, {...imageGenerationDto });
     }
+
+    async getImageGenerationService( fileName: string ) {
+        const filePath = path.resolve( './',  './genereted/image/', fileName);
+        console.log(filePath);
+        const wasFound = fs.existsSync(filePath);
+        if( !wasFound )throw new NotFoundException(' El archivo no fue encontrado');
+
+        return filePath;
+    }
 }

--- a/src/gpt/use-cases/image-generation.use-case.ts
+++ b/src/gpt/use-cases/image-generation.use-case.ts
@@ -3,6 +3,7 @@
 
 import OpenAI from "openai";
 import * as fs from 'fs'
+import { downloadImageAsPng } from "src/helpers/download-image-as-png";
 
 interface Options {
     prompt: string;
@@ -20,8 +21,11 @@ export const imageGenerationUseCase = async ( openAi: OpenAI, options: Options) 
         quality: 'standard',
         response_format: 'url',
     });
-   
+    
+    await downloadImageAsPng(resp.data![0].url!);
+    
     console.log(resp);
+
     return {
         url: resp.data![0].url,
         localPath: '',

--- a/src/helpers/download-image-as-png.ts
+++ b/src/helpers/download-image-as-png.ts
@@ -1,0 +1,25 @@
+import { InternalServerErrorException } from "@nestjs/common";
+import * as path from "path";
+import * as fs from 'fs';
+
+
+
+export const  downloadImageAsPng = async(url: string) => {
+
+    const response = await fetch(url);
+    
+    if(!response.ok) {
+        throw new InternalServerErrorException(`Failed to download image: ${response.statusText}`);
+    }
+
+    const folderPath = path.resolve('./', './genereted/image/');
+    const fileName = `${ new Date().getTime() }.png`;
+    fs.mkdirSync(folderPath, { recursive: true });
+
+    const buffer = Buffer.from(await response.arrayBuffer());
+
+    fs.writeFileSync( `${folderPath}/${fileName}`, buffer);
+
+
+
+}


### PR DESCRIPTION
Funcionalidad para gestionar la generación y recuperación de imágenes en el módulo GPT. Añade un nuevo punto de acceso para obtener las imágenes generadas, implementa una función auxiliar para descargar imágenes como archivos PNG e integra esta funcionalidad en el flujo de trabajo de generación de imágenes existente.

### Nuevo punto de acceso para la recuperación de imágenes:
* [`src/gpt/gpt.controller.ts`](diffhunk://#diff-33eb9e9c915070eaf04bb0d887cb00bc08911c2049f8b281fe9961db45b3c076R124-R135): Se ha añadido un nuevo punto de acceso `getImageGeneration` para servir las imágenes generadas por nombre de archivo. Recupera la ruta del archivo del servicio, establece los encabezados correspondientes y envía el archivo como respuesta.

### Mejoras del servicio para la gestión de imágenes:
* [`src/gpt/gpt.service.ts`](diffhunk://#diff-4aa51463cc528e5fb54d7525d69103935a60b96db5ce63ff6b37cf74246bfe4dR65-R73): Se añadió `getImageGenerationService` para localizar y validar la existencia de los archivos de imagen generados. Se genera una `NotFoundException` si no se encuentra el archivo.

Integración de la función de descarga de imágenes:
* [`src/gpt/use-cases/image-generation.use-case.ts`](diffhunk://#diff-0649c8a06abfa2e3fb530aa7c458de897820795593d1095bf27858d831f511a2R25-R28): Se integró la función auxiliar `downloadImageAsPng` en `imageGenerationUseCase` para descargar y guardar la imagen generada localmente tras recibir una URL de la API de OpenAI.

### Nueva herramienta para descargar imágenes:
* [`src/helpers/download-image-as-png.ts`](diffhunk://#diff-f5a1e40180bb4256df64d11d56c47ff1394cd4906b70744dba2e1aa102086a4fR1-R25): Se añadió la función `downloadImageAsPng` para obtener una imagen de una URL, guardarla como archivo PNG en una carpeta designada y gestionar errores durante el proceso.

### Actualizaciones de dependencias:
* [`src/gpt/use-cases/image-generation.use-case.ts`](diffhunk://#diff-0649c8a06abfa2e3fb530aa7c458de897820795593d1095bf27858d831f511a2R6): Se importó el nuevo asistente `downloadImageAsPng` para respaldar el flujo de trabajo de generación de imágenes.