### PR TITLE
Recibiendo la url de la imagen guardada

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,3 +1,4 @@
 
 # https://platform.openai.com/settings/organization/api-keys
 API_KEY=gpt-api-key
+SERVER_URL=http://localhost:3000/

--- a/src/gpt/dtos/image-variation.dto.ts
+++ b/src/gpt/dtos/image-variation.dto.ts
@@ -1,0 +1,8 @@
+import { IsString } from "class-validator";
+
+
+export class ImageVariationDto {
+    
+    @IsString()
+    readonly baseImage : string;
+}

--- a/src/gpt/gpt.controller.ts
+++ b/src/gpt/gpt.controller.ts
@@ -9,6 +9,7 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import { diskStorage } from 'multer';
 import { AudioToTextDto } from './dtos/audio-to-text.dto';
 import { ImageGenerationDto } from './dtos/image-genaration.dto';
+import { ImageVariationDto } from './dtos/image-variation.dto';
 
 @Controller('gpt')
 export class GptController {
@@ -133,4 +134,12 @@ export class GptController {
     res.status(HttpStatus.OK);
     res.sendFile(filePath);
   }
+
+  @Post('image-variation')
+  async imageVariation(
+    @Body() imageVariationDto: ImageVariationDto
+  ) {
+    return this.gptService.imageVariationService( imageVariationDto );
+  }
+
 }

--- a/src/gpt/gpt.service.ts
+++ b/src/gpt/gpt.service.ts
@@ -15,6 +15,9 @@ import { audioToTextUseCase } from './use-cases/audio-to-text.use-case';
 import { AudioToTextDto } from './dtos/audio-to-text.dto';
 import { ImageGenerationDto } from './dtos/image-genaration.dto';
 import { imageGenerationUseCase } from './use-cases/image-generation.use-case';
+import { ImageVariationDto } from './dtos/image-variation.dto';
+import { generate } from 'rxjs';
+import { imageVariationUseCase } from './use-cases/image-variation.use-case';
 
 @Injectable()
 export class GptService {
@@ -70,5 +73,9 @@ export class GptService {
         if( !wasFound )throw new NotFoundException(' El archivo no fue encontrado');
 
         return filePath;
+    }
+
+    async imageVariationService( { baseImage }: ImageVariationDto ) {
+        return imageVariationUseCase(this.openAi, { baseImage: baseImage });
     }
 }

--- a/src/gpt/use-cases/image-generation.use-case.ts
+++ b/src/gpt/use-cases/image-generation.use-case.ts
@@ -24,7 +24,8 @@ export const imageGenerationUseCase = async ( openAi: OpenAI, options: Options) 
             response_format: 'url',
         });
         
-        const url = await downloadImageAsPng(resp.data![0].url!);
+        const fileName = await downloadImageAsPng(resp.data![0].url!);
+        const url = `${process.env.SERVER_URL}gpt/image-generation/${fileName}`; //localhost:3000/gpt/image-generation/1754247056558.png
     
         return {
             url: url,
@@ -46,13 +47,11 @@ export const imageGenerationUseCase = async ( openAi: OpenAI, options: Options) 
         response_format: 'url', 
     });
 
-    const localImagePath = await downloadImageAsPng(resp.data![0].url!);
-    const fileName = path.basename(localImagePath);
-
-    const publicUrl = `loclahost:3000/ ${fileName}`;
+    const fileName = await downloadImageAsPng(resp.data![0].url!);
+    const url = `${process.env.SERVER_URL}gpt/image-generation/${fileName}`; //localhost:3000/gpt/image-generation/1754247056558.png;
 
     return {
-        url: publicUrl,
+        url: url,
         openAiUrl: resp.data![0].url,
         revised_prompt: resp.data![0].revised_prompt,
         fileName: fileName

--- a/src/gpt/use-cases/image-variation.use-case.ts
+++ b/src/gpt/use-cases/image-variation.use-case.ts
@@ -1,0 +1,26 @@
+import OpenAI from "openai";
+
+
+
+interface Option {
+    baseImage: string;
+}
+
+export const imageVariationUseCase = async (openAi: OpenAI, option: Option) => {
+
+    const { baseImage } = option;
+
+    return baseImage;
+
+    /* const response = await openAi.chat.completions.create({
+        model: 'gpt-4',
+        messages: [
+            {
+                role: 'user',
+                content: `Crea una variación de esta imagen: ${baseImage}`
+            }
+        ]
+    });
+
+    return response; */
+};

--- a/src/helpers/download-image-as-png.ts
+++ b/src/helpers/download-image-as-png.ts
@@ -15,21 +15,17 @@ export const  downloadImageAsPng = async(url: string) => {
     }
 
     const folderPath = path.resolve('./', './genereted/image/');
-    const fileName = `${ new Date().getTime() }.png`;
+    const ImageNamePng = `${ new Date().getTime() }.png`;
     fs.mkdirSync(folderPath, { recursive: true });
 
     const buffer = Buffer.from(await response.arrayBuffer());
 
     //fs.writeFileSync( `${folderPath}/${fileName}`, buffer);
+    const completePath = path.join(folderPath, ImageNamePng);
 
-    await sharp(buffer)
-        .png()  
-        .ensureAlpha()
-        .toFile(path.join(folderPath, fileName));
+    await sharp(buffer).png().ensureAlpha().toFile(completePath);
 
-    return path.join(folderPath, fileName);
-    
-
+    return ImageNamePng;
 
 }
 
@@ -44,14 +40,10 @@ export const downloadBase64ImageAsPng = async (base64Image: string) => {
   fs.mkdirSync(folderPath, { recursive: true });
 
   const imageNamePng = `${ new Date().getTime() }-64.png`;
-  
-
+  const completePath = path.join(folderPath, imageNamePng);
   // Transformar a RGBA, png // Así lo espera OpenAI
-  await sharp(imageBuffer)
-    .png()
-    .ensureAlpha()
-    .toFile(path.join(folderPath, imageNamePng));
+  await sharp(imageBuffer).png().ensureAlpha().toFile(completePath);
 
-  return path.join(folderPath, imageNamePng);
+  return imageNamePng;
 
 }


### PR DESCRIPTION
El módulo GPT admite la funcionalidad de variación de imágenes y refactoriza los asistentes de generación y descarga de imágenes para mayor consistencia. Introduce un nuevo DTO y un caso de uso para la variación de imágenes, actualiza las capas de controlador y servicio para gestionar el nuevo endpoint y mejora la construcción y devolución de las URL de las imágenes generadas.

**Función de Variación de Imágenes:**

* Se añadió `ImageVariationDto` con validación y se integró en el controlador (`GptController`) y el servicio (`GptService`), exponiendo un nuevo endpoint `POST /gpt/image-variation`. También se introduce el stub del caso de uso correspondiente (`imageVariationUseCase`). [[1]](diffhunk://#diff-1bb89efd6cd7bd28f747703369fbd92197db7f028603577e7ae4cdffc024621cR1-R8) [[2]](diffhunk://#diff-33eb9e9c915070eaf04bb0d887cb00bc08911c2049f8b281fe9961db45b3c076R12) [[3]](diffhunk://#diff-33eb9e9c915070eaf04bb0d887cb00bc08911c2049f8b281fe9961db45b3c076R137-R144) [[4]](diffhunk://#diff-4aa51463cc528e5fb54d7525d69103935a60b96db5ce63ff6b37cf74246bfe4dR18-R20) [[5]](diffhunk://#diff-4aa51463cc528e5fb54d7525d69103935a60b96db5ce63ff6b37cf74246bfe4dR77-R80) [[6]](diffhunk://#diff-ad7d97bbef95d6b0a3d8bdd0d7d44da038fe925893741597078be3d92da60b52R1-R26)

**Generación de imágenes y Refactorización de descargas:**

* Se actualizaron los ayudantes `downloadImageAsPng` y `downloadBase64ImageAsPng` para que devuelvan solo el nombre del archivo de imagen en lugar de la ruta completa, y se ajustó su uso en el caso de uso de generación de imágenes para construir URL públicas mediante la nueva variable de entorno `SERVER_URL`. [[1]](diffhunk://#diff-f5a1e40180bb4256df64d11d56c47ff1394cd4906b70744dba2e1aa102086a4fL18-R28) [[2]](diffhunk://#diff-f5a1e40180bb4256df64d11d56c47ff1394cd4906b70744dba2e1aa102086a4fL47-R47) [[3]](diffhunk://#diff-0649c8a06abfa2e3fb530aa7c458de897820795593d1095bf27858d831f511a2L27-R28) [[4]](diffhunk://#diff-0649c8a06abfa2e3fb530aa7c458de897820795593d1095bf27858d831f511a2L49-R54)

**Configuración:**

* Se añadió `SERVER_URL` a `.env.template` para construir las URL públicas de las imágenes generadas.