### PR TITLE
Recibiendo los mensajes del asistente en el backend

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -2,3 +2,5 @@
 # https://platform.openai.com/settings/organization/api-keys
 API_KEY=gpt-api-key
 SERVER_URL=http://localhost:3000/
+
+ASSISTANT_ID=your_assistant_id

--- a/src/sam-assistant/sam-assistant.controller.ts
+++ b/src/sam-assistant/sam-assistant.controller.ts
@@ -15,6 +15,6 @@ export class SamAssistantController {
   async userQuestion(
     @Body() questionDto: QuestionDto
   ) {
-    return this.samAssistantService.userQuestion(questionDto);
+    return this.samAssistantService.userQuestion( questionDto);
   }
 }

--- a/src/sam-assistant/sam-assistant.service.ts
+++ b/src/sam-assistant/sam-assistant.service.ts
@@ -1,6 +1,11 @@
 import { Injectable } from '@nestjs/common';
 import OpenAI from 'openai';
 import { CreateThreatUseCase } from './use-cases/create-threat.use-case';
+import { QuestionDto } from './dtos/question.dto';
+import { CreateMessageUseCase } from './use-cases/create-message.use-case';
+import { createRunUseCase } from './use-cases/create-run.use-case';
+import { CheckCompleteStatusUseCase } from './use-cases/check-complete-status.use-case';
+import { getMessageListUseCase } from './use-cases/get-message-list.use-case';
 
 @Injectable()
 export class SamAssistantService {
@@ -13,10 +18,19 @@ export class SamAssistantService {
         return await CreateThreatUseCase( this.openAi );
     }
 
-    async userQuestion(
-        questionDto: { threadId: string; question: string }
-    ) {
-        // Lógica para manejar la pregunta del usuario
-        return { answer: 'Respuesta a la pregunta del usuario' };
+    async userQuestion( questionDto:  QuestionDto ) {
+        const { threadId, question } = questionDto;
+        /// Lógica para manejar la pregunta del usuario
+        const message = await CreateMessageUseCase( this.openAi, { threadId, question } );
+
+        const run = await createRunUseCase( this.openAi, { threadId } );
+
+        await CheckCompleteStatusUseCase( this.openAi, { threadId, runId: run.id } );
+
+        const messages = await getMessageListUseCase( this.openAi, { threadId } );
+
+        return messages.reverse();
     }
+
+
 }

--- a/src/sam-assistant/use-cases/check-complete-status.use-case.ts
+++ b/src/sam-assistant/use-cases/check-complete-status.use-case.ts
@@ -1,0 +1,31 @@
+import OpenAI from "openai";
+
+interface Options {
+    threadId: string;
+    runId: string;
+}
+
+export const CheckCompleteStatusUseCase = async (openAi: OpenAI, options: Options) => {
+    const { threadId, runId } = options;
+
+    try {
+        // La API OpenAI v5.10.1 usa esta estructura exacta
+        const runStatus = await openAi.beta.threads.runs.retrieve(           
+            runId,
+            { thread_id: threadId } // RequestOptions opcional
+        );
+
+        console.log({ status: runStatus.status });
+        
+        if (runStatus.status === 'completed') {
+            return runStatus;
+        }
+
+        await new Promise(resolve => setTimeout(resolve, 1000)); // Esperar 1 segundo antes de reintentar
+        return await CheckCompleteStatusUseCase(openAi, { threadId, runId });
+
+    } catch (error: any) {
+        console.error('Error retrieving run status:', error);
+        throw new Error(`Error retrieving run status: ${error?.message || error}`);
+    }
+}

--- a/src/sam-assistant/use-cases/create-message.use-case.ts
+++ b/src/sam-assistant/use-cases/create-message.use-case.ts
@@ -1,0 +1,20 @@
+
+
+interface Option {
+    threadId: string;
+    question: string;
+}
+
+
+export const CreateMessageUseCase = async ( openAi: any, option: Option ) => {
+
+    const { threadId, question } = option;
+
+    const message = await openAi.beta.threads.messages.create(  threadId, {
+        role: 'user',
+        content: question,
+    });
+
+    return message;
+
+}

--- a/src/sam-assistant/use-cases/create-run.use-case.ts
+++ b/src/sam-assistant/use-cases/create-run.use-case.ts
@@ -1,0 +1,24 @@
+import OpenAI from 'openai';
+
+interface Options {
+    threadId: string;
+    assistantId?: string;
+}
+
+export const createRunUseCase = async (openAi: OpenAI, options: Options) => {
+    const { threadId, assistantId } = options;
+
+    // Validar que assistantId esté definido
+    const finalAssistantId = assistantId || process.env.ASSISTANT_ID;
+    
+    if (!finalAssistantId) {
+        throw new Error('ASSISTANT_ID is required but not provided in options or environment variables');
+    }
+
+    const run = await openAi.beta.threads.runs.create(threadId, {
+        assistant_id: finalAssistantId, 
+        // instructions: OJO que cambia el asistente
+    });
+
+    return run;
+};

--- a/src/sam-assistant/use-cases/create-threat.use-case.ts
+++ b/src/sam-assistant/use-cases/create-threat.use-case.ts
@@ -1,8 +1,6 @@
 import OpenAI from "openai"
 
 
-
-
 export const  CreateThreatUseCase = async (openai: OpenAI) => {
     const { id } = await openai.beta.threads.create();
     return { id };

--- a/src/sam-assistant/use-cases/get-message-list.use-case.ts
+++ b/src/sam-assistant/use-cases/get-message-list.use-case.ts
@@ -1,0 +1,32 @@
+import OpenAI from "openai";
+
+interface Options {
+    threadId: string;
+}
+
+export const getMessageListUseCase = async (openAi: OpenAI, options: Options) => {
+    const { threadId } = options;
+
+    try {
+        // La API OpenAI v5.10.1 usa esta estructura exacta
+        const messagesList = await openAi.beta.threads.messages.list(
+            threadId 
+        );
+
+        console.log(messagesList)
+
+        const messages = messagesList.data.map(msg => ({
+            id: msg.id,
+            role: msg.role,
+            content: msg.content.map( c => (c as any).text.value ),
+            
+        }));
+
+        return messages;
+
+    } catch (error: any) {
+        console.error('Error retrieving message list:', error);
+        throw new Error(`Error retrieving message list: ${error?.message || error}`);
+    }
+
+}


### PR DESCRIPTION
Se introducen mejoras significativas en `SamAssistantService` al implementar completamente el flujo de trabajo de gestión de preguntas de usuario e integrar varios casos de uso nuevos para interactuar con la API de OpenAI. Los cambios mejoran la capacidad del servicio para procesar preguntas de usuario, gestionar ejecuciones de hilos, comprobar el estado de finalización de las ejecuciones y recuperar el historial de mensajes. Además, se ha actualizado la configuración del entorno para que sea compatible con la funcionalidad del asistente.

**Mejoras en el flujo de trabajo de preguntas de usuario:**

* El método `userQuestion` en `SamAssistantService` ya está completamente implementado. Crea un mensaje de usuario, inicia una ejecución, verifica su finalización y devuelve la lista invertida de mensajes, aprovechando los nuevos módulos de casos de uso para cada paso.

**Nuevos casos de uso para la interacción con la API de OpenAI:**

* Se ha añadido `CreateMessageUseCase` para enviar mensajes de usuario a un hilo.
* Se ha añadido `createRunUseCase` para iniciar una ejecución en un hilo, validando y utilizando `ASSISTANT_ID` de las variables de entorno si no se proporciona. * Se añadió `CheckCompleteStatusUseCase` para sondear y esperar hasta que se complete una ejecución, con gestión de errores y lógica de reintento.
* Se añadió `getMessageListUseCase` para recuperar y formatear la lista de mensajes de un hilo.

**Actualización de configuración:**

* Se actualizó `.env.template` para incluir la variable `ASSISTANT_ID`, necesaria para la función de ejecución del asistente.